### PR TITLE
add ints to smt primitives

### DIFF
--- a/tests/smt-bool.egg
+++ b/tests/smt-bool.egg
@@ -4,3 +4,9 @@
 
 (check (unsat (and p (not p))))
 (fail (check (unsat (and p p))))
+
+(let x (smt-int-const "x"))
+(let y (smt-int-const "y"))
+
+(check (unsat (smt-= x (+ x (smt-int 1)))))
+(check (unsat (smt-= (- x y) (+ (- x y) (smt-int 1)))))


### PR DESCRIPTION
added smt ints, and capability to query them using `smt-=` inside the smt-bool type